### PR TITLE
Potential fix for code scanning alert no. 1: Inefficient regular expression

### DIFF
--- a/src/components/email-component/email-component.ts
+++ b/src/components/email-component/email-component.ts
@@ -18,7 +18,7 @@ export class EmailComponent extends ActionSheetParent {
         Validators.compose([
           Validators.required,
           Validators.pattern(
-            /(?:[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[A-Za-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[A-Za-z0-9-]*[A-Za-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/
+            /^[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)+$/
           )
         ])
       ),


### PR DESCRIPTION
Potential fix for [https://github.com/lillithlynn/wallet/security/code-scanning/1](https://github.com/lillithlynn/wallet/security/code-scanning/1)

General fix: avoid overly complex RFC-complete regexes in JavaScript form validators; use a simpler, anchored, non-ambiguous email pattern that does not contain nested ambiguous quantified alternations.

Best fix here (without changing surrounding functionality): in `src/components/email-component/email-component.ts`, replace the current `Validators.pattern(...)` regex (line 21 region) with a safer, simpler email regex that covers common valid emails and avoids catastrophic backtracking. Keep `Validators.required` unchanged and keep the form structure untouched.

Concretely:
- Edit only the regex literal passed to `Validators.pattern(...)`.
- Use an anchored regex like:
  - local part: `[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+`
  - `@`
  - domain labels with dots and TLD-like ending: `[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)+`
- This avoids the problematic quoted/local-literal RFC branches that caused backtracking blowups.

No imports, helper methods, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
