### PR TITLE
Potential fix for code scanning alert no. 17: Insecure randomness

### DIFF
--- a/src/providers/coinbase/coinbase.ts
+++ b/src/providers/coinbase/coinbase.ts
@@ -66,10 +66,11 @@ export class CoinbaseProvider {
   }
 
   private getRandomHex(): string {
-    const characters = '0123456789abcdef';
+    const bytes = new Uint8Array(20);
+    window.crypto.getRandomValues(bytes);
     let str = '';
-    for (let i = 0; i < 40; i++) {
-      str += characters[Math.floor(Math.random() * 16)];
+    for (let i = 0; i < bytes.length; i++) {
+      str += ('00' + bytes[i].toString(16)).slice(-2);
     }
     return str;
   }


### PR DESCRIPTION
Potential fix for [https://github.com/lillithlynn/wallet/security/code-scanning/17](https://github.com/lillithlynn/wallet/security/code-scanning/17)

Use a cryptographically secure RNG to generate the OAuth `state` value instead of `Math.random()`.

Best fix in this file: replace `getRandomHex()` implementation to use `window.crypto.getRandomValues` (browser-secure RNG). Generate 20 random bytes (160 bits) and convert to a 40-character hex string, preserving existing behavior/format (`[0-9a-f]{40}`) and avoiding functional changes to call sites (`this.credentials.STATE = this.getRandomHex();` stays unchanged).

Changes needed in `src/providers/coinbase/coinbase.ts`:
- Edit only `getRandomHex()` (lines 68–75 region).
- No new imports are required since Web Crypto is accessed via global `window.crypto`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
